### PR TITLE
Fix line names not being saved

### DIFF
--- a/AutoLineColor/Constants.cs
+++ b/AutoLineColor/Constants.cs
@@ -7,6 +7,7 @@ namespace AutoLineColor {
         public const string ModName = "Auto Line Color";
         public const string Description = 
                     "Monitors all transport line looking for lines set to the default color." +
-                    " When found it sets a new color and a line name";
+                    " When found it sets a new color and a line name.";
+        public const double UpdateIntervalSeconds = 10.0;
     }
 }


### PR DESCRIPTION
This fixes the bug where changes to the line name weren't saved.

`TransportManager.SetLineName` does set the line name (via the `InstanceManager`), but it's a coroutine, so calling the method isn't enough to make it run; it returns an IEnumerator that needs to be enumerated. The call to `SetLineColor` had the same problem, but changes to the color were still being applied because the code also set `m_flags` and `m_color` directly.

I've removed the direct field access, and changed both calls to pass the coroutines to `SimulationManager.AddAction` to run them on the simulation thread.